### PR TITLE
Refactoring to use original XNA SetDataPointerEXT() and GetData()

### DIFF
--- a/Assets/Scripts/ClassicUO/src/Game/GameCursor.cs
+++ b/Assets/Scripts/ClassicUO/src/Game/GameCursor.cs
@@ -88,15 +88,11 @@ namespace ClassicUO.Game
                 {
                     ushort id = _cursorData[i, j];
 
-                    // MobileUO: SDL_CreateRGBSurfaceWithFormatFrom isn't implemented in our XNA version, so we must use previous logic instead of ArtLoader.Instance.CreateCursorSurfacePtr
-
-                    //IntPtr surface = ArtLoader.Instance.CreateCursorSurfacePtr(id, (ushort) (i == 2 ? 0x0033 : 0), out short w, out short h);
-                    uint[] pixels = ArtLoader.Instance.ReadStaticArt(id, out short w, out short h, out _);
+                    IntPtr surface = ArtLoader.Instance.CreateCursorSurfacePtr(id, (ushort) (i == 2 ? 0x0033 : 0), out short w, out short h);
                  
                     if (i == 0)
                     {
-                        //if (surface != IntPtr.Zero)
-                        if (pixels != null && pixels.Length > 0)
+                        if (surface != IntPtr.Zero)
                         {
                             float offX = 0;
                             float offY = 0;
@@ -223,49 +219,14 @@ namespace ClassicUO.Game
                             _cursorOffset[1, j] = 0;
                         }
                     }
-                    // MobileUO: commented out
-                    // if (pixels != null && pixels.Length != 0)
-                    // {
-                    //     unsafe
-                    //     {
-                    //         fixed (uint* ptr = pixels)
-                    //         {
-                    //             SDL.SDL_Surface* surface = (SDL.SDL_Surface*) SDL.SDL_CreateRGBSurfaceWithFormatFrom((IntPtr) ptr, w, h, 32, 4 * w, SDL.SDL_PIXELFORMAT_ABGR8888);
-                    //             
-                    //             if (i == 2)
-                    //             {
-                    //                 int stride = surface->pitch >> 2;
-                    //                 uint* pixels_ptr = (uint*) surface->pixels;
-                    //                 uint* p_line_end = pixels_ptr + w;
-                    //                 uint* p_img_end = pixels_ptr + (stride * h);
-                    //                 int delta = stride - w;
-                    //                 Color c = default;
-                    //
-                    //                 while (pixels_ptr < p_img_end)
-                    //                 {
-                    //                     while (pixels_ptr < p_line_end)
-                    //                     {
-                    //                         if (*pixels_ptr != 0 && *pixels_ptr != 0xFF_00_00_00)
-                    //                         {
-                    //                             c.PackedValue = *pixels_ptr;
-                    //                             * pixels_ptr = HuesHelper.Color16To32(HuesLoader.Instance.GetColor16(HuesHelper.ColorToHue(c), 0x0033)) | 0xFF_00_00_00;
-                    //                         }
-                    //
-                    //                         ++pixels_ptr;
-                    //                     }
-                    //
-                    //                     pixels_ptr += delta;
-                    //                     p_line_end += stride;
-                    //                 }
-                    //             }
-                    //
-                    //             int hotX = -_cursorOffset[0, j];
-                    //             int hotY = -_cursorOffset[1, j];
-                    //
-                    //             _cursors_ptr[i, j] = SDL.SDL_CreateColorCursor((IntPtr) surface, hotX, hotY);
-                    //         }
-                    //     }
-                    // }
+
+                    if (surface != IntPtr.Zero)
+                    {
+                        int hotX = -_cursorOffset[0, j];
+                        int hotY = -_cursorOffset[1, j];
+
+                        _cursors_ptr[i, j] = SDL.SDL_CreateColorCursor(surface, hotX, hotY);
+                    }
                 }
             }
         }

--- a/Assets/Scripts/ClassicUO/src/Game/GameObjects/Views/ItemView.cs
+++ b/Assets/Scripts/ClassicUO/src/Game/GameObjects/Views/ItemView.cs
@@ -202,33 +202,30 @@ namespace ClassicUO.Game.GameObjects
                 posX -= index.Width;
                 posY -= index.Height;
 
-                // MobileUO: use old method
-                if (SelectedObject.IsPointInStatic(texture, posX, posY))
+                // MobileUO: pass in texture
+                if (ArtLoader.Instance.PixelCheck
+                (
+                    graphic,
+                    texture,
+                    SelectedObject.TranslatedMousePositionByViewport.X - posX,
+                    SelectedObject.TranslatedMousePositionByViewport.Y - posY
+                ))
                 {
                     SelectedObject.Object = this;
                 }
-
-                //if (ArtLoader.Instance.PixelCheck
-                //(
-                //    graphic,
-                //    SelectedObject.TranslatedMousePositionByViewport.X - posX,
-                //    SelectedObject.TranslatedMousePositionByViewport.Y - posY
-                //))
-                //{
-                //    SelectedObject.Object = this;
-                //}
-                //else if (!IsMulti && !IsCoin && Amount > 1 && ItemData.IsStackable)
-                //{
-                //    if (ArtLoader.Instance.PixelCheck
-                //    (
-                //        graphic,
-                //        SelectedObject.TranslatedMousePositionByViewport.X - posX + 5,
-                //        SelectedObject.TranslatedMousePositionByViewport.Y - posY + 5
-                //    ))
-                //    {
-                //        SelectedObject.Object = this;
-                //    }
-                //}
+                else if (!IsMulti && !IsCoin && Amount > 1 && ItemData.IsStackable)
+                {
+                    if (ArtLoader.Instance.PixelCheck
+                    (
+                        graphic,
+                        texture,
+                        SelectedObject.TranslatedMousePositionByViewport.X - posX + 5,
+                        SelectedObject.TranslatedMousePositionByViewport.Y - posY + 5
+                    ))
+                    {
+                        SelectedObject.Object = this;
+                    }
+                }
             }
 
             return true;
@@ -462,9 +459,8 @@ namespace ClassicUO.Game.GameObjects
                     return;
                 }
 
-                // MobileUO: use old method
-                if (frame.Contains(flipped ? posX + frame.Width - SelectedObject.TranslatedMousePositionByViewport.X : SelectedObject.TranslatedMousePositionByViewport.X - posX, SelectedObject.TranslatedMousePositionByViewport.Y - posY))
-                //if (AnimationsLoader.Instance.PixelCheck(graphic, animGroup, dir, direction.IsUOP, animIndex, flipped ? posX + frame.Width - SelectedObject.TranslatedMousePositionByViewport.X : SelectedObject.TranslatedMousePositionByViewport.X - posX, SelectedObject.TranslatedMousePositionByViewport.Y - posY))
+                // MobileUO: pass in texture
+                if (AnimationsLoader.Instance.PixelCheck(graphic, frame, animGroup, dir, direction.IsUOP, animIndex, flipped ? posX + frame.Width - SelectedObject.TranslatedMousePositionByViewport.X : SelectedObject.TranslatedMousePositionByViewport.X - posX, SelectedObject.TranslatedMousePositionByViewport.Y - posY))
                 {
                     SelectedObject.Object = owner;
                 }

--- a/Assets/Scripts/ClassicUO/src/Game/GameObjects/Views/ItemView.cs
+++ b/Assets/Scripts/ClassicUO/src/Game/GameObjects/Views/ItemView.cs
@@ -202,11 +202,9 @@ namespace ClassicUO.Game.GameObjects
                 posX -= index.Width;
                 posY -= index.Height;
 
-                // MobileUO: pass in texture
                 if (ArtLoader.Instance.PixelCheck
                 (
                     graphic,
-                    texture,
                     SelectedObject.TranslatedMousePositionByViewport.X - posX,
                     SelectedObject.TranslatedMousePositionByViewport.Y - posY
                 ))
@@ -218,7 +216,6 @@ namespace ClassicUO.Game.GameObjects
                     if (ArtLoader.Instance.PixelCheck
                     (
                         graphic,
-                        texture,
                         SelectedObject.TranslatedMousePositionByViewport.X - posX + 5,
                         SelectedObject.TranslatedMousePositionByViewport.Y - posY + 5
                     ))
@@ -459,8 +456,7 @@ namespace ClassicUO.Game.GameObjects
                     return;
                 }
 
-                // MobileUO: pass in texture
-                if (AnimationsLoader.Instance.PixelCheck(graphic, frame, animGroup, dir, direction.IsUOP, animIndex, flipped ? posX + frame.Width - SelectedObject.TranslatedMousePositionByViewport.X : SelectedObject.TranslatedMousePositionByViewport.X - posX, SelectedObject.TranslatedMousePositionByViewport.Y - posY))
+                if (AnimationsLoader.Instance.PixelCheck(graphic, animGroup, dir, direction.IsUOP, animIndex, flipped ? posX + frame.Width - SelectedObject.TranslatedMousePositionByViewport.X : SelectedObject.TranslatedMousePositionByViewport.X - posX, SelectedObject.TranslatedMousePositionByViewport.Y - posY))
                 {
                     SelectedObject.Object = owner;
                 }

--- a/Assets/Scripts/ClassicUO/src/Game/GameObjects/Views/MobileView.cs
+++ b/Assets/Scripts/ClassicUO/src/Game/GameObjects/Views/MobileView.cs
@@ -802,8 +802,7 @@ namespace ClassicUO.Game.GameObjects
                         }
                     }
 
-                    // MobileUO: pass in texture
-                    if (AnimationsLoader.Instance.PixelCheck(id, frame, animGroup, dir, direction.IsUOP, frameIndex, mirror ? x + frame.Width - SelectedObject.TranslatedMousePositionByViewport.X : SelectedObject.TranslatedMousePositionByViewport.X - x, SelectedObject.TranslatedMousePositionByViewport.Y - y))
+                    if (AnimationsLoader.Instance.PixelCheck(id, animGroup, dir, direction.IsUOP, frameIndex, mirror ? x + frame.Width - SelectedObject.TranslatedMousePositionByViewport.X : SelectedObject.TranslatedMousePositionByViewport.X - x, SelectedObject.TranslatedMousePositionByViewport.Y - y))
                     {
                         SelectedObject.Object = owner;
                     }

--- a/Assets/Scripts/ClassicUO/src/Game/GameObjects/Views/MobileView.cs
+++ b/Assets/Scripts/ClassicUO/src/Game/GameObjects/Views/MobileView.cs
@@ -802,9 +802,8 @@ namespace ClassicUO.Game.GameObjects
                         }
                     }
 
-                    // MobileUO: use old method
-                    if (frame.Contains(mirror ? x + frame.Width - SelectedObject.TranslatedMousePositionByViewport.X : SelectedObject.TranslatedMousePositionByViewport.X - x, SelectedObject.TranslatedMousePositionByViewport.Y - y))
-                    //if (AnimationsLoader.Instance.PixelCheck(id, animGroup, dir, direction.IsUOP, frameIndex, mirror ? x + frame.Width - SelectedObject.TranslatedMousePositionByViewport.X : SelectedObject.TranslatedMousePositionByViewport.X - x, SelectedObject.TranslatedMousePositionByViewport.Y - y))
+                    // MobileUO: pass in texture
+                    if (AnimationsLoader.Instance.PixelCheck(id, frame, animGroup, dir, direction.IsUOP, frameIndex, mirror ? x + frame.Width - SelectedObject.TranslatedMousePositionByViewport.X : SelectedObject.TranslatedMousePositionByViewport.X - x, SelectedObject.TranslatedMousePositionByViewport.Y - y))
                     {
                         SelectedObject.Object = owner;
                     }

--- a/Assets/Scripts/ClassicUO/src/Game/GameObjects/Views/MultiView.cs
+++ b/Assets/Scripts/ClassicUO/src/Game/GameObjects/Views/MultiView.cs
@@ -172,13 +172,11 @@ namespace ClassicUO.Game.GameObjects
                 posX -= index.Width;
                 posY -= index.Height;
 
-                // MobileUO: pass in texture
                 ArtTexture texture = ArtLoader.Instance.GetTexture(graphic);
 
                 if (ArtLoader.Instance.PixelCheck
                 (
                     graphic,
-                    texture,
                     SelectedObject.TranslatedMousePositionByViewport.X - posX,
                     SelectedObject.TranslatedMousePositionByViewport.Y - posY
                 ))

--- a/Assets/Scripts/ClassicUO/src/Game/GameObjects/Views/MultiView.cs
+++ b/Assets/Scripts/ClassicUO/src/Game/GameObjects/Views/MultiView.cs
@@ -172,20 +172,19 @@ namespace ClassicUO.Game.GameObjects
                 posX -= index.Width;
                 posY -= index.Height;
 
-                // MobileUO: use old method
-                if (SelectedObject.IsPointInStatic(ArtLoader.Instance.GetTexture(graphic), posX, posY))
+                // MobileUO: pass in texture
+                ArtTexture texture = ArtLoader.Instance.GetTexture(graphic);
+
+                if (ArtLoader.Instance.PixelCheck
+                (
+                    graphic,
+                    texture,
+                    SelectedObject.TranslatedMousePositionByViewport.X - posX,
+                    SelectedObject.TranslatedMousePositionByViewport.Y - posY
+                ))
                 {
                     SelectedObject.Object = this;
                 }
-                //if (ArtLoader.Instance.PixelCheck
-                //(
-                //    graphic,
-                //    SelectedObject.TranslatedMousePositionByViewport.X - posX,
-                //    SelectedObject.TranslatedMousePositionByViewport.Y - posY
-                //))
-                //{
-                //    SelectedObject.Object = this;
-                //}
             }
 
             return true;

--- a/Assets/Scripts/ClassicUO/src/Game/GameObjects/Views/StaticView.cs
+++ b/Assets/Scripts/ClassicUO/src/Game/GameObjects/Views/StaticView.cs
@@ -131,20 +131,19 @@ namespace ClassicUO.Game.GameObjects
                 posX -= index.Width;
                 posY -= index.Height;
 
-                // MobileUO: use old method
-                if (SelectedObject.IsPointInStatic(ArtLoader.Instance.GetTexture(graphic), posX, posY))
+                // MobileUO: pass in texture
+                ArtTexture texture = ArtLoader.Instance.GetTexture(graphic);
+
+                if (ArtLoader.Instance.PixelCheck
+                (
+                    graphic,
+                    texture,
+                    SelectedObject.TranslatedMousePositionByViewport.X - posX,
+                    SelectedObject.TranslatedMousePositionByViewport.Y - posY
+                ))
                 {
                     SelectedObject.Object = this;
                 }
-                //if (ArtLoader.Instance.PixelCheck
-                //(
-                //graphic,
-                //    SelectedObject.TranslatedMousePositionByViewport.X - posX, 
-                //    SelectedObject.TranslatedMousePositionByViewport.Y - posY
-                //))
-                //{
-                //    SelectedObject.Object = this;
-                //}
             }
 
             return true;

--- a/Assets/Scripts/ClassicUO/src/Game/GameObjects/Views/StaticView.cs
+++ b/Assets/Scripts/ClassicUO/src/Game/GameObjects/Views/StaticView.cs
@@ -131,13 +131,11 @@ namespace ClassicUO.Game.GameObjects
                 posX -= index.Width;
                 posY -= index.Height;
 
-                // MobileUO: pass in texture
                 ArtTexture texture = ArtLoader.Instance.GetTexture(graphic);
 
                 if (ArtLoader.Instance.PixelCheck
                 (
                     graphic,
-                    texture,
                     SelectedObject.TranslatedMousePositionByViewport.X - posX,
                     SelectedObject.TranslatedMousePositionByViewport.Y - posY
                 ))

--- a/Assets/Scripts/ClassicUO/src/Game/Managers/TextRenderer.cs
+++ b/Assets/Scripts/ClassicUO/src/Game/Managers/TextRenderer.cs
@@ -81,8 +81,7 @@ namespace ClassicUO.Game.Managers
                     }
                 }
 
-                // MobileUO: pass in texture
-                if (item.RenderedText.PixelCheck(item.RenderedText.Texture, mouseX - startX - item.RealScreenPosition.X, mouseY - startY - item.RealScreenPosition.Y))
+                if (item.RenderedText.PixelCheck(mouseX - startX - item.RealScreenPosition.X, mouseY - startY - item.RealScreenPosition.Y))
                 {
                     SelectedObject.LastObject = item;
                 }
@@ -135,8 +134,7 @@ namespace ClassicUO.Game.Managers
                 int x = o.RealScreenPosition.X;
                 int y = o.RealScreenPosition.Y;
 
-                // MobileUO: pass in texture
-                if (o.RenderedText.PixelCheck(o.RenderedText.Texture, mouseX - x - startX, mouseY - y - startY))
+                if (o.RenderedText.PixelCheck(mouseX - x - startX, mouseY - y - startY))
                 {
                     if (isGump)
                     {

--- a/Assets/Scripts/ClassicUO/src/Game/Managers/TextRenderer.cs
+++ b/Assets/Scripts/ClassicUO/src/Game/Managers/TextRenderer.cs
@@ -81,9 +81,8 @@ namespace ClassicUO.Game.Managers
                     }
                 }
 
-                // MobileUO keep old method
-                if (item.RenderedText.Texture.Contains(mouseX - startX - item.RealScreenPosition.X, mouseY - startY - item.RealScreenPosition.Y))
-                //if (item.RenderedText.PixelCheck(mouseX - startX - item.RealScreenPosition.X, mouseY - startY - item.RealScreenPosition.Y))
+                // MobileUO: pass in texture
+                if (item.RenderedText.PixelCheck(item.RenderedText.Texture, mouseX - startX - item.RealScreenPosition.X, mouseY - startY - item.RealScreenPosition.Y))
                 {
                     SelectedObject.LastObject = item;
                 }
@@ -136,9 +135,8 @@ namespace ClassicUO.Game.Managers
                 int x = o.RealScreenPosition.X;
                 int y = o.RealScreenPosition.Y;
 
-                // MobileUO: use old method
-                if (o.RenderedText.Texture.Contains(mouseX - x - startX, mouseY - y - startY))
-                //if (o.RenderedText.PixelCheck(mouseX - x - startX, mouseY - y - startY))
+                // MobileUO: pass in texture
+                if (o.RenderedText.PixelCheck(o.RenderedText.Texture, mouseX - x - startX, mouseY - y - startY))
                 {
                     if (isGump)
                     {

--- a/Assets/Scripts/ClassicUO/src/Game/SelectedObject.cs
+++ b/Assets/Scripts/ClassicUO/src/Game/SelectedObject.cs
@@ -65,11 +65,6 @@ namespace ClassicUO.Game
             }
         }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool IsPointInStatic(UOTexture texture, int x, int y)
-        {
-            return texture != null && texture.Contains(TranslatedMousePositionByViewport.X - x, TranslatedMousePositionByViewport.Y - y);
-        }
         
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool IsPointInLand(int x, int y)

--- a/Assets/Scripts/ClassicUO/src/Game/UI/Controls/Button.cs
+++ b/Assets/Scripts/ClassicUO/src/Game/UI/Controls/Button.cs
@@ -373,8 +373,7 @@ namespace ClassicUO.Game.UI.Controls
                 return false;
             }
 
-            // MobileUO: pass in texture
-            return ContainsByBounds ? base.Contains(x, y) : GumpsLoader.Instance.PixelCheck(_gumpGraphics[NORMAL], _textures[NORMAL], x - Offset.X, y - Offset.Y);
+            return ContainsByBounds ? base.Contains(x, y) : GumpsLoader.Instance.PixelCheck(_gumpGraphics[NORMAL], x - Offset.X, y - Offset.Y);
         }
 
         public sealed override void Dispose()

--- a/Assets/Scripts/ClassicUO/src/Game/UI/Controls/Button.cs
+++ b/Assets/Scripts/ClassicUO/src/Game/UI/Controls/Button.cs
@@ -373,9 +373,8 @@ namespace ClassicUO.Game.UI.Controls
                 return false;
             }
 
-            // MobileUO: keep old method
-            return ContainsByBounds ? base.Contains(x, y) : _textures[NORMAL].Contains(x - Offset.X, y - Offset.Y);
-            //return ContainsByBounds ? base.Contains(x, y) : GumpsLoader.Instance.PixelCheck(_gumpGraphics[NORMAL], x - Offset.X, y - Offset.Y);
+            // MobileUO: pass in texture
+            return ContainsByBounds ? base.Contains(x, y) : GumpsLoader.Instance.PixelCheck(_gumpGraphics[NORMAL], _textures[NORMAL], x - Offset.X, y - Offset.Y);
         }
 
         public sealed override void Dispose()

--- a/Assets/Scripts/ClassicUO/src/Game/UI/Controls/GumpPic.cs
+++ b/Assets/Scripts/ClassicUO/src/Game/UI/Controls/GumpPic.cs
@@ -85,9 +85,8 @@ namespace ClassicUO.Game.UI.Controls
                 return false;
             }
 
-            // MobileUO: use old method
-            if (texture.Contains(x - Offset.X, y - Offset.Y))
-            //if (GumpsLoader.Instance.PixelCheck(Graphic, x - Offset.X, y - Offset.Y))
+            // MobileUO: pass in texture
+            if (GumpsLoader.Instance.PixelCheck(Graphic, texture, x - Offset.X, y - Offset.Y))
             {
                 return true;
             }

--- a/Assets/Scripts/ClassicUO/src/Game/UI/Controls/GumpPic.cs
+++ b/Assets/Scripts/ClassicUO/src/Game/UI/Controls/GumpPic.cs
@@ -85,8 +85,7 @@ namespace ClassicUO.Game.UI.Controls
                 return false;
             }
 
-            // MobileUO: pass in texture
-            if (GumpsLoader.Instance.PixelCheck(Graphic, texture, x - Offset.X, y - Offset.Y))
+            if (GumpsLoader.Instance.PixelCheck(Graphic, x - Offset.X, y - Offset.Y))
             {
                 return true;
             }

--- a/Assets/Scripts/ClassicUO/src/Game/UI/Controls/GumpPicTiled.cs
+++ b/Assets/Scripts/ClassicUO/src/Game/UI/Controls/GumpPicTiled.cs
@@ -175,8 +175,7 @@ namespace ClassicUO.Game.UI.Controls
                 return false;
             }
 
-            // MobileUO: pass in texture
-            return GumpsLoader.Instance.PixelCheck(Graphic, texture, x, y);
+            return GumpsLoader.Instance.PixelCheck(Graphic, x, y);
         }
     }
 }

--- a/Assets/Scripts/ClassicUO/src/Game/UI/Controls/GumpPicTiled.cs
+++ b/Assets/Scripts/ClassicUO/src/Game/UI/Controls/GumpPicTiled.cs
@@ -175,9 +175,8 @@ namespace ClassicUO.Game.UI.Controls
                 return false;
             }
 
-            // MobileUO: use old method
-            return texture.Contains(x, y);
-            //return GumpsLoader.Instance.PixelCheck(Graphic, x, y);
+            // MobileUO: pass in texture
+            return GumpsLoader.Instance.PixelCheck(Graphic, texture, x, y);
         }
     }
 }

--- a/Assets/Scripts/ClassicUO/src/Game/UI/Controls/ItemGump.cs
+++ b/Assets/Scripts/ClassicUO/src/Game/UI/Controls/ItemGump.cs
@@ -207,9 +207,7 @@ namespace ClassicUO.Game.UI.Controls
 
             if (_is_gump)
             {
-                // MobileUO: added PixelCheck
-                // MobileUO: pass in texture
-                if (GumpsLoader.Instance.PixelCheck(Graphic, texture, x, y, PixelCheck))
+                if (GumpsLoader.Instance.PixelCheck(Graphic, x, y))
                 {
                     return true;
                 }
@@ -218,9 +216,7 @@ namespace ClassicUO.Game.UI.Controls
 
                 if (item != null && !item.IsCoin && item.Amount > 1 && item.ItemData.IsStackable)
                 {
-                    // MobileUO: added PixelCheck
-                    // MobileUO: pass in texture
-                    if (GumpsLoader.Instance.PixelCheck(Graphic, texture, x - 5, y - 5, PixelCheck))
+                    if (GumpsLoader.Instance.PixelCheck(Graphic, x - 5, y - 5))
                     {
                         return true;
                     }
@@ -228,9 +224,7 @@ namespace ClassicUO.Game.UI.Controls
             }
             else
             {
-                // MobileUO: added PixelCheck
-                // MobileUO: pass in texture
-                if (ArtLoader.Instance.PixelCheck(Graphic, texture, x, y, PixelCheck))
+                if (ArtLoader.Instance.PixelCheck(Graphic, x, y))
                 {
                     return true;
                 }
@@ -239,9 +233,7 @@ namespace ClassicUO.Game.UI.Controls
 
                 if (item != null && !item.IsCoin && item.Amount > 1 && item.ItemData.IsStackable)
                 {
-                    // MobileUO: added PixelCheck
-                    // MobileUO: pass in texture
-                    if (ArtLoader.Instance.PixelCheck(Graphic, texture, x - 5, y - 5, PixelCheck))
+                    if (ArtLoader.Instance.PixelCheck(Graphic, x - 5, y - 5))
                     {
                         return true;
                     }

--- a/Assets/Scripts/ClassicUO/src/Game/UI/Controls/ItemGump.cs
+++ b/Assets/Scripts/ClassicUO/src/Game/UI/Controls/ItemGump.cs
@@ -208,9 +208,8 @@ namespace ClassicUO.Game.UI.Controls
             if (_is_gump)
             {
                 // MobileUO: added PixelCheck
-                // MobileUO: use old method
-                if (texture.Contains(x, y, PixelCheck))
-                //if (GumpsLoader.Instance.PixelCheck(Graphic, x, y, PixelCheck))
+                // MobileUO: pass in texture
+                if (GumpsLoader.Instance.PixelCheck(Graphic, texture, x, y, PixelCheck))
                 {
                     return true;
                 }
@@ -220,9 +219,8 @@ namespace ClassicUO.Game.UI.Controls
                 if (item != null && !item.IsCoin && item.Amount > 1 && item.ItemData.IsStackable)
                 {
                     // MobileUO: added PixelCheck
-                    // MobileUO: use old method
-                    if (texture.Contains(x - 5, y - 5, PixelCheck))
-                    //if (GumpsLoader.Instance.PixelCheck(Graphic, x - 5, y - 5, PixelCheck))
+                    // MobileUO: pass in texture
+                    if (GumpsLoader.Instance.PixelCheck(Graphic, texture, x - 5, y - 5, PixelCheck))
                     {
                         return true;
                     }
@@ -231,9 +229,8 @@ namespace ClassicUO.Game.UI.Controls
             else
             {
                 // MobileUO: added PixelCheck
-                // MobileUO: use old method
-                if (texture.Contains(x, y, PixelCheck))
-                //if (ArtLoader.Instance.PixelCheck(Graphic, x, y, PixelCheck))
+                // MobileUO: pass in texture
+                if (ArtLoader.Instance.PixelCheck(Graphic, texture, x, y, PixelCheck))
                 {
                     return true;
                 }
@@ -243,9 +240,8 @@ namespace ClassicUO.Game.UI.Controls
                 if (item != null && !item.IsCoin && item.Amount > 1 && item.ItemData.IsStackable)
                 {
                     // MobileUO: added PixelCheck
-                    // MobileUO: use old method
-                    if (texture.Contains(x - 5, y - 5, PixelCheck))
-                    //if (ArtLoader.Instance.PixelCheck(Graphic, x - 5, y - 5, PixelCheck))
+                    // MobileUO: pass in texture
+                    if (ArtLoader.Instance.PixelCheck(Graphic, texture, x - 5, y - 5, PixelCheck))
                     {
                         return true;
                     }

--- a/Assets/Scripts/ClassicUO/src/Game/UI/Controls/ResizePic.cs
+++ b/Assets/Scripts/ClassicUO/src/Game/UI/Controls/ResizePic.cs
@@ -352,8 +352,7 @@ namespace ClassicUO.Game.UI.Controls
                 return false;
             }
 
-            // MobileUO: pass in texture
-            return GumpsLoader.Instance.PixelCheck(graphic, texture, x, y);
+            return GumpsLoader.Instance.PixelCheck(graphic, x, y);
         }
 
         public override bool Draw(UltimaBatcher2D batcher, int x, int y)

--- a/Assets/Scripts/ClassicUO/src/Game/UI/Controls/ResizePic.cs
+++ b/Assets/Scripts/ClassicUO/src/Game/UI/Controls/ResizePic.cs
@@ -352,9 +352,8 @@ namespace ClassicUO.Game.UI.Controls
                 return false;
             }
 
-            // MobileUO: use old method
-            return texture.Contains(x, y);
-            //return GumpsLoader.Instance.PixelCheck(graphic, x, y);
+            // MobileUO: pass in texture
+            return GumpsLoader.Instance.PixelCheck(graphic, texture, x, y);
         }
 
         public override bool Draw(UltimaBatcher2D batcher, int x, int y)

--- a/Assets/Scripts/ClassicUO/src/Game/UI/Controls/ScrollFlag.cs
+++ b/Assets/Scripts/ClassicUO/src/Game/UI/Controls/ScrollFlag.cs
@@ -170,9 +170,8 @@ namespace ClassicUO.Game.UI.Controls
 
             y -= _sliderPosition;
 
-            // MobileUO: use old method
-            return texture_flag.Contains(x, y);
-            //return GumpsLoader.Instance.PixelCheck(0x0828, x, y);
+            // MobileUO: pass in texture
+            return GumpsLoader.Instance.PixelCheck(0x0828, texture_flag, x, y);
         }
     }
 }

--- a/Assets/Scripts/ClassicUO/src/Game/UI/Controls/ScrollFlag.cs
+++ b/Assets/Scripts/ClassicUO/src/Game/UI/Controls/ScrollFlag.cs
@@ -170,8 +170,7 @@ namespace ClassicUO.Game.UI.Controls
 
             y -= _sliderPosition;
 
-            // MobileUO: pass in texture
-            return GumpsLoader.Instance.PixelCheck(0x0828, texture_flag, x, y);
+            return GumpsLoader.Instance.PixelCheck(0x0828, x, y);
         }
     }
 }

--- a/Assets/Scripts/ClassicUO/src/Game/UI/Controls/StaticPic.cs
+++ b/Assets/Scripts/ClassicUO/src/Game/UI/Controls/StaticPic.cs
@@ -109,11 +109,10 @@ namespace ClassicUO.Game.UI.Controls
 
         public override bool Contains(int x, int y)
         {
-            // MobileUO: use old method
+            // MobileUO: pass in texture
             ArtTexture texture = ArtLoader.Instance.GetTexture(Graphic);
 
-            return texture != null && texture.Contains(x - Offset.X, y - Offset.Y);
-            //return ArtLoader.Instance.PixelCheck(Graphic, x - Offset.X, y - Offset.Y);
+            return ArtLoader.Instance.PixelCheck(Graphic, texture, x - Offset.X, y - Offset.Y);
         }
     }
 }

--- a/Assets/Scripts/ClassicUO/src/Game/UI/Controls/StaticPic.cs
+++ b/Assets/Scripts/ClassicUO/src/Game/UI/Controls/StaticPic.cs
@@ -109,10 +109,7 @@ namespace ClassicUO.Game.UI.Controls
 
         public override bool Contains(int x, int y)
         {
-            // MobileUO: pass in texture
-            ArtTexture texture = ArtLoader.Instance.GetTexture(Graphic);
-
-            return ArtLoader.Instance.PixelCheck(Graphic, texture, x - Offset.X, y - Offset.Y);
+            return ArtLoader.Instance.PixelCheck(Graphic, x - Offset.X, y - Offset.Y);
         }
     }
 }

--- a/Assets/Scripts/ClassicUO/src/Game/UI/Gumps/MiniMapGump.cs
+++ b/Assets/Scripts/ClassicUO/src/Game/UI/Gumps/MiniMapGump.cs
@@ -468,9 +468,8 @@ namespace ClassicUO.Game.UI.Gumps
 
         public override bool Contains(int x, int y)
         {
-            // MobileUO: use old method
-            return _mapTexture.Contains(x - Offset.X, y - Offset.Y);
-            //return _picker.Get((ulong) (_useLargeMap ? 0x01 : 0x00), x - Offset.X, y - Offset.Y);
+            // MobileUO: pass in texture
+            return _picker.Get((ulong) (_useLargeMap ? 0x01 : 0x00), _mapTexture, x - Offset.X, y - Offset.Y);
         }
 
         public override void Dispose()

--- a/Assets/Scripts/ClassicUO/src/Game/UI/Gumps/MiniMapGump.cs
+++ b/Assets/Scripts/ClassicUO/src/Game/UI/Gumps/MiniMapGump.cs
@@ -89,29 +89,22 @@ namespace ClassicUO.Game.UI.Gumps
 
             if (_blankGumpsPixels[index] == null)
             {
-                // MobileUO: our version of XNA doesn't have GetData() for textures, reverting to previous logic
-                //int size = _gumpTexture.Width * _gumpTexture.Height;
-                //uint[] data = System.Buffers.ArrayPool<uint>.Shared.Rent(size);
+                int size = _gumpTexture.Width * _gumpTexture.Height;
+                uint[] data = System.Buffers.ArrayPool<uint>.Shared.Rent(size);
 
-                //try
-                //{
-                //    _gumpTexture.GetData(data, 0, size);
+                try
+                {
+                    _gumpTexture.GetData(data, 0, size);
 
-                //    _blankGumpsPixels[index] = new uint[size];
-                //    _blankGumpsPixels[index + 2] = new uint[size];
+                    _blankGumpsPixels[index] = new uint[size];
+                    _blankGumpsPixels[index + 2] = new uint[size];
 
-                //    Array.Copy(data, 0, _blankGumpsPixels[index], 0, size);
-                //}
-                //finally
-                //{
-                //    System.Buffers.ArrayPool<uint>.Shared.Return(data, true);
-                //}
-
-                uint[] data = _gumpTexture.Data;
-                _blankGumpsPixels[index] = new uint[data.Length];
-                _blankGumpsPixels[index + 2] = new uint[data.Length];
-
-                data.CopyTo(_blankGumpsPixels[index], 0);
+                    Array.Copy(data, 0, _blankGumpsPixels[index], 0, size);
+                }
+                finally
+                {
+                    System.Buffers.ArrayPool<uint>.Shared.Return(data, true);
+                }
             }
 
             Width = _gumpTexture.Width;
@@ -468,8 +461,7 @@ namespace ClassicUO.Game.UI.Gumps
 
         public override bool Contains(int x, int y)
         {
-            // MobileUO: pass in texture
-            return _picker.Get((ulong) (_useLargeMap ? 0x01 : 0x00), _mapTexture, x - Offset.X, y - Offset.Y);
+            return _picker.Get((ulong) (_useLargeMap ? 0x01 : 0x00), x - Offset.X, y - Offset.Y);
         }
 
         public override void Dispose()

--- a/Assets/Scripts/ClassicUO/src/IO/PixelPicker.cs
+++ b/Assets/Scripts/ClassicUO/src/IO/PixelPicker.cs
@@ -67,10 +67,11 @@ namespace ClassicUO.IO
         }
 
         // MobileUO: this logic existed in the old UOTexture class
-        // MobileUO: TODO: ideally, it would be better if we could somehow grab the texture by the textureID instead of passing it down to the function
-        // MobileUO: TODO: or figure out how to get the other Get() function to work correctly
+        // MobileUO: it's probably no longer needed
         public bool Get(ulong textureID, Microsoft.Xna.Framework.Graphics.Texture2D texture, int x, int y, int extraRange = 0, bool pixelCheck = true)
         {
+            //return Get(textureID, x, y, extraRange);
+
             if (x >= 0 && y >= 0 && x < texture.Width && y < texture.Height)
             {
                 if (!pixelCheck)

--- a/Assets/Scripts/ClassicUO/src/IO/Resources/AnimationsLoader.cs
+++ b/Assets/Scripts/ClassicUO/src/IO/Resources/AnimationsLoader.cs
@@ -44,6 +44,7 @@ using ClassicUO.Renderer;
 using ClassicUO.Utility;
 using ClassicUO.Utility.Logging;
 using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
 
 namespace ClassicUO.IO.Resources
 {
@@ -1065,13 +1066,14 @@ namespace ClassicUO.IO.Resources
             _usedTextures.Clear();
         }
 
-        public bool PixelCheck(ushort animID, byte group, byte direction, bool uop, int frame, int x, int y)
+        // MobileUO: pass in texture
+        public bool PixelCheck(ushort animID, Texture2D texture, byte group, byte direction, bool uop, int frame, int x, int y)
         {
             uint packed32 = (uint)((group | (direction << 8) | ((uop ? 0x01 : 0x00) << 16)));
             uint packed32_2 = (uint)((animID | (frame << 16)));
             ulong packed = (packed32_2 | ((ulong)packed32 << 32));
 
-            return _picker.Get(packed, x, y);
+            return _picker.Get(packed, texture, x, y);
         }
 
         public void UpdateAnimationTable(uint flags)

--- a/Assets/Scripts/ClassicUO/src/IO/Resources/AnimationsLoader.cs
+++ b/Assets/Scripts/ClassicUO/src/IO/Resources/AnimationsLoader.cs
@@ -1066,14 +1066,13 @@ namespace ClassicUO.IO.Resources
             _usedTextures.Clear();
         }
 
-        // MobileUO: pass in texture
-        public bool PixelCheck(ushort animID, Texture2D texture, byte group, byte direction, bool uop, int frame, int x, int y)
+        public bool PixelCheck(ushort animID, byte group, byte direction, bool uop, int frame, int x, int y)
         {
             uint packed32 = (uint)((group | (direction << 8) | ((uop ? 0x01 : 0x00) << 16)));
             uint packed32_2 = (uint)((animID | (frame << 16)));
             ulong packed = (packed32_2 | ((ulong)packed32 << 32));
 
-            return _picker.Get(packed, texture, x, y);
+            return _picker.Get(packed, x, y);
         }
 
         public void UpdateAnimationTable(uint flags)

--- a/Assets/Scripts/ClassicUO/src/IO/Resources/ArtLoader.cs
+++ b/Assets/Scripts/ClassicUO/src/IO/Resources/ArtLoader.cs
@@ -40,6 +40,7 @@ using ClassicUO.Game.Data;
 using ClassicUO.Renderer;
 using ClassicUO.Utility;
 using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
 using SDL2;
 
 namespace ClassicUO.IO.Resources
@@ -211,10 +212,10 @@ namespace ClassicUO.IO.Resources
             return IntPtr.Zero;
         }
 
-        public bool PixelCheck(int index, int x, int y, bool pixelCheck = true)
+        // MobileUO: added texture and pixel check
+        public bool PixelCheck(int index, Texture2D texture, int x, int y, bool pixelCheck = true)
         {
-            // MobileUO: TODO: implement pixelCheck flag?
-            return _picker.Get((ulong) index, x, y);
+            return _picker.Get((ulong) index, texture, x, y);
         }
 
         public override bool TryGetEntryInfo(int entry, out long address, out long size, out long compressedSize)

--- a/Assets/Scripts/ClassicUO/src/IO/Resources/ArtLoader.cs
+++ b/Assets/Scripts/ClassicUO/src/IO/Resources/ArtLoader.cs
@@ -212,10 +212,9 @@ namespace ClassicUO.IO.Resources
             return IntPtr.Zero;
         }
 
-        // MobileUO: added texture and pixel check
-        public bool PixelCheck(int index, Texture2D texture, int x, int y, bool pixelCheck = true)
+        public bool PixelCheck(int index, int x, int y)
         {
-            return _picker.Get((ulong) index, texture, x, y);
+            return _picker.Get((ulong) index, x, y);
         }
 
         public override bool TryGetEntryInfo(int entry, out long address, out long size, out long compressedSize)
@@ -388,172 +387,51 @@ namespace ClassicUO.IO.Resources
             bounds.Height = maxY - minY;
         }
 
-        // MobileUO: keeping function since SetDataPointerEXT is not implemented
-        public unsafe uint[] ReadStaticArt(ushort graphic, out short width, out short height, out Rectangle bounds)
+        private unsafe void ReadStaticArt(ref ArtTexture texture, ushort graphic)
         {
             ref UOFileIndex entry = ref GetValidRefEntry(graphic + 0x4000);
 
-            bounds = Rectangle.Empty;
-
-            if (entry.Length == 0)
+            if (ReadHeader(_file, ref entry, out short width, out short height))
             {
-                width = 0;
-                height = 0;
+                uint[] buffer = null;
 
-                return null;
-            }
+                // MobileUO: we get graphical issues with smaller art when using stackalloc uint[1024]
+                Span<uint> pixels = width * height <= 1024 ? stackalloc uint[width * height] : (buffer = System.Buffers.ArrayPool<uint>.Shared.Rent(width * height));
 
-            _file.SetData(entry.Address, entry.FileSize);
-            _file.Seek(entry.Offset);
-            _file.Skip(4);
-            width = _file.ReadShort();
-            height = _file.ReadShort();
-
-            if (width == 0 || height == 0)
-            {
-                return null;
-            }
-
-            uint[] pixels = new uint[width * height];
-            ushort* ptr = (ushort*) _file.PositionAddress;
-            ushort* lineoffsets = ptr;
-            byte* datastart = (byte*) ptr + height * 2;
-            int x = 0;
-            int y = 0;
-            ptr = (ushort*) (datastart + lineoffsets[0] * 2);
-            int minX = width, minY = height, maxX = 0, maxY = 0;
-
-            while (y < height)
-            {
-                ushort xoffs = *ptr++;
-                ushort run = *ptr++;
-
-                if (xoffs + run >= 2048)
+                try
                 {
-                    return null;
-                }
-
-                if (xoffs + run != 0)
-                {
-                    x += xoffs;
-                    int pos = y * width + x;
-
-                    for (int j = 0; j < run; ++j, ++pos)
+                    if (ReadData(pixels, width, height, _file))
                     {
-                        ushort val = *ptr++;
+                        texture = new ArtTexture(width, height);
 
-                        if (val != 0)
+                        FinalizeData
+                        (
+                            pixels,
+                            ref entry,
+                            graphic,
+                            width,
+                            height,
+                            out texture.ImageRectangle
+                        );
+
+
+                        fixed (uint* ptr = pixels)
                         {
-                            pixels[pos] = HuesHelper.Color16To32(val) | 0xFF_00_00_00;
-                        }
-                    }
-
-                    x += run;
-                }
-                else
-                {
-                    x = 0;
-                    ++y;
-                    ptr = (ushort*) (datastart + lineoffsets[y] * 2);
-                }
-            }
-
-            if (graphic >= 0x2053 && graphic <= 0x2062 || graphic >= 0x206A && graphic <= 0x2079)
-            {
-                for (int i = 0; i < width; i++)
-                {
-                    pixels[i] = 0;
-                    pixels[(height - 1) * width + i] = 0;
-                }
-
-                for (int i = 0; i < height; i++)
-                {
-                    pixels[i * width] = 0;
-                    pixels[i * width + width - 1] = 0;
-                }
-            }
-            else if (StaticFilters.IsCave(graphic) && ProfileManager.CurrentProfile != null && ProfileManager.CurrentProfile.EnableCaveBorder)
-            {
-                for (int yy = 0; yy < height; yy++)
-                {
-                    int startY = yy != 0 ? -1 : 0;
-                    int endY = yy + 1 < height ? 2 : 1;
-
-                    for (int xx = 0; xx < width; xx++)
-                    {
-                        ref uint pixel = ref pixels[yy * width + xx];
-
-                        if (pixel == 0)
-                        {
-                            continue;
-                        }
-
-                        int startX = xx != 0 ? -1 : 0;
-                        int endX = xx + 1 < width ? 2 : 1;
-
-                        for (int i = startY; i < endY; i++)
-                        {
-                            int currentY = yy + i;
-
-                            for (int j = startX; j < endX; j++)
-                            {
-                                int currentX = xx + j;
-
-                                ref uint currentPixel = ref pixels[currentY * width + currentX];
-
-                                if (currentPixel == 0u)
-                                {
-                                    pixel = 0xFF_00_00_00;
-                                }
-                            }
+                            texture.SetDataPointerEXT(0, null, (IntPtr)ptr, width * height * sizeof(uint));
                         }
                     }
                 }
-            }
-
-            int pos1 = 0;
-
-            for (y = 0; y < height; ++y)
-            {
-                for (x = 0; x < width; ++x)
+                finally
                 {
-                    if (pixels[pos1++] != 0)
+                    if (buffer != null)
                     {
-                        minX = Math.Min(minX, x);
-                        maxX = Math.Max(maxX, x);
-                        minY = Math.Min(minY, y);
-                        maxY = Math.Max(maxY, y);
+                        System.Buffers.ArrayPool<uint>.Shared.Return(buffer, true);
                     }
                 }
-            }
-
-
-            entry.Width = (short) ((width >> 1) - 22);
-            entry.Height = (short) (height - 44);
-
-            bounds.X = minX;
-            bounds.Y = minY;
-            bounds.Width = maxX - minX;
-            bounds.Height = maxY - minY;
-
-            return pixels;
-        }
-
-        // MobileUO: SetDataPointerEXT is not implemented, continue to use PushData implementation
-        private unsafe void ReadStaticArt(ref ArtTexture texture, ushort graphic)
-        {
-            uint[] pixels = ReadStaticArt(graphic, out short width, out short height, out Rectangle rect);
-
-            if (pixels != null)
-            {
-                texture = new ArtTexture(width, height);
-                texture.ImageRectangle = rect;
-                texture.PushData(pixels);
             }
         }
 
-        // MobileUO: SetDataPointerEXT is not implemented, continue to use SetData implementation
-        private void ReadLandArt(ref UOTexture texture, ushort graphic)
+        private unsafe void ReadLandArt(ref UOTexture texture, ushort graphic)
         {
             const int SIZE = 44 * 44;
 
@@ -562,14 +440,15 @@ namespace ClassicUO.IO.Resources
 
             if (entry.Length == 0)
             {
-                texture = new UOTexture(44,44);
+                texture = null;
+
                 return;
             }
 
             _file.SetData(entry.Address, entry.FileSize);
             _file.Seek(entry.Offset);
 
-            uint[] data = new uint[SIZE];
+            uint* data = stackalloc uint[SIZE];
 
             for (int i = 0; i < 22; ++i)
             {
@@ -600,7 +479,7 @@ namespace ClassicUO.IO.Resources
             texture = new UOTexture(44, 44);
             // we don't need to store the data[] pointer because
             // land is always hoverable
-            texture.SetData(data);
+            texture.SetDataPointerEXT(0, null, (IntPtr) data, SIZE * sizeof(uint));
         }
 
         private void AddBlackBorder(Span<uint> pixels, int width, int height)

--- a/Assets/Scripts/ClassicUO/src/IO/Resources/GumpsLoader.cs
+++ b/Assets/Scripts/ClassicUO/src/IO/Resources/GumpsLoader.cs
@@ -185,10 +185,10 @@ namespace ClassicUO.IO.Resources
             _instance = null;
         }
 
-        public bool PixelCheck(int index, int x, int y, bool pixelCheck = true)
+        // MobileUO: added texture and pixelCheck
+        public bool PixelCheck(int index, Microsoft.Xna.Framework.Graphics.Texture2D texture, int x, int y, bool pixelCheck = true)
         {
-            // MobileUO: TODO: implement pixelCheck flag?
-            return _picker.Get((ulong) index, x, y);
+            return _picker.Get((ulong) index, texture, x, y);
         }
 
         // MobileUO: keep old version of this function

--- a/Assets/Scripts/ClassicUO/src/Renderer/RenderedText.cs
+++ b/Assets/Scripts/ClassicUO/src/Renderer/RenderedText.cs
@@ -270,8 +270,7 @@ namespace ClassicUO.Renderer
             return _info;
         }
 
-        // MobileUO: added texture
-        public bool PixelCheck(Texture2D texture, int x, int y)
+        public bool PixelCheck(int x, int y)
         {
             if (string.IsNullOrWhiteSpace(Text))
             {
@@ -287,7 +286,7 @@ namespace ClassicUO.Renderer
 
             ulong b = (ulong)(Text.GetHashCode() ^ hue ^ ((int)Align) ^ ((int)FontStyle) ^ Font ^ (IsUnicode ? 0x01 : 0x00));
 
-            return _picker.Get(b, texture, x, y);
+            return _picker.Get(b, x, y);
         }
 
         public TextEditRow GetLayoutRow(int startIndex)

--- a/Assets/Scripts/ClassicUO/src/Renderer/RenderedText.cs
+++ b/Assets/Scripts/ClassicUO/src/Renderer/RenderedText.cs
@@ -37,6 +37,7 @@ using ClassicUO.IO.Resources;
 using ClassicUO.Utility;
 using ClassicUO.Utility.Collections;
 using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
 using StbTextEditSharp;
 
 namespace ClassicUO.Renderer
@@ -269,7 +270,8 @@ namespace ClassicUO.Renderer
             return _info;
         }
 
-        public bool PixelCheck(int x, int y)
+        // MobileUO: added texture
+        public bool PixelCheck(Texture2D texture, int x, int y)
         {
             if (string.IsNullOrWhiteSpace(Text))
             {
@@ -285,7 +287,7 @@ namespace ClassicUO.Renderer
 
             ulong b = (ulong)(Text.GetHashCode() ^ hue ^ ((int)Align) ^ ((int)FontStyle) ^ Font ^ (IsUnicode ? 0x01 : 0x00));
 
-            return _picker.Get(b, x, y);
+            return _picker.Get(b, texture, x, y);
         }
 
         public TextEditRow GetLayoutRow(int startIndex)

--- a/Assets/Scripts/ClassicUO/src/Utility/GraphicHelper.cs
+++ b/Assets/Scripts/ClassicUO/src/Utility/GraphicHelper.cs
@@ -80,87 +80,54 @@ namespace ClassicUO.Utility
             UOTexture[] r = new UOTexture[partXYplusWidthHeight.GetLength(0)];
             int pwidth = original.Width;   //((original.Width + 1) >> 1) << 1;
             int pheight = original.Height; //((original.Height + 1) >> 1) << 1;
-            // MobileUO: our version of XNA doesn't have GetData() for textures, reverting to previous logic
-            //uint[] originalData = System.Buffers.ArrayPool<uint>.Shared.Rent(pwidth * pheight);
+            uint[] originalData = System.Buffers.ArrayPool<uint>.Shared.Rent(pwidth * pheight);
 
-            //original.GetData(originalData, 0, pwidth * pheight);
+            original.GetData(originalData, 0, pwidth * pheight);
 
-            //try
-            //{
-            //    int index = 0;
-
-            //    for (int p = 0; p < partXYplusWidthHeight.GetLength(0); p++)
-            //    {
-            //        int x = partXYplusWidthHeight[p, 0], y = partXYplusWidthHeight[p, 1], width = partXYplusWidthHeight[p, 2], height = partXYplusWidthHeight[p, 3];
-
-            //        uint[] partData = System.Buffers.ArrayPool<uint>.Shared.Rent(width * height);
-
-            //        try
-            //        {
-            //            UOTexture part = new UOTexture(width, height);
-
-            //            for (int py = 0; py < height; py++)
-            //            {
-            //                for (int px = 0; px < width; px++)
-            //                {
-            //                    int partIndex = px + py * width;
-
-            //                    //If a part goes outside of the source texture, then fill the overlapping part with transparent
-            //                    if (y + py >= pheight || x + px >= pwidth)
-            //                    {
-            //                        partData[partIndex] = 0;
-            //                    }
-            //                    else
-            //                    {
-            //                        partData[partIndex] = originalData[x + px + (y + py) * pwidth];
-            //                    }
-            //                }
-            //            }
-
-            //            part.SetData(partData, 0, width * height);
-            //            r[index++] = part;
-            //        }
-            //        finally
-            //        {
-            //            System.Buffers.ArrayPool<uint>.Shared.Return(partData, true);
-            //        }
-            //    }
-            //}
-            //finally
-            //{
-            //    System.Buffers.ArrayPool<uint>.Shared.Return(originalData, true);
-            //}
-            uint[] originalData = original.Data;
-
-            int index = 0;
-
-            for (int p = 0; p < partXYplusWidthHeight.GetLength(0); p++)
+            try
             {
-                int x = partXYplusWidthHeight[p, 0], y = partXYplusWidthHeight[p, 1], width = partXYplusWidthHeight[p, 2], height = partXYplusWidthHeight[p, 3];
+                int index = 0;
 
-                UOTexture part = new UOTexture(width, height);
-                uint[] partData = new uint[width * height];
-
-                for (int py = 0; py < height; py++)
+                for (int p = 0; p < partXYplusWidthHeight.GetLength(0); p++)
                 {
-                    for (int px = 0; px < width; px++)
-                    {
-                        int partIndex = px + py * width;
+                    int x = partXYplusWidthHeight[p, 0], y = partXYplusWidthHeight[p, 1], width = partXYplusWidthHeight[p, 2], height = partXYplusWidthHeight[p, 3];
 
-                        //If a part goes outside of the source texture, then fill the overlapping part with transparent
-                        if (y + py >= pheight || x + px >= pwidth)
+                    uint[] partData = System.Buffers.ArrayPool<uint>.Shared.Rent(width * height);
+
+                    try
+                    {
+                        UOTexture part = new UOTexture(width, height);
+
+                        for (int py = 0; py < height; py++)
                         {
-                            partData[partIndex] = 0;
+                            for (int px = 0; px < width; px++)
+                            {
+                                int partIndex = px + py * width;
+
+                                //If a part goes outside of the source texture, then fill the overlapping part with transparent
+                                if (y + py >= pheight || x + px >= pwidth)
+                                {
+                                    partData[partIndex] = 0;
+                                }
+                                else
+                                {
+                                    partData[partIndex] = originalData[x + px + (y + py) * pwidth];
+                                }
+                            }
                         }
-                        else
-                        {
-                            partData[partIndex] = originalData[x + px + (y + py) * pwidth];
-                        }
+
+                        part.SetData(partData, 0, width * height);
+                        r[index++] = part;
+                    }
+                    finally
+                    {
+                        System.Buffers.ArrayPool<uint>.Shared.Return(partData, true);
                     }
                 }
-
-                part.PushData(partData);
-                r[index++] = part;
+            }
+            finally
+            {
+                System.Buffers.ArrayPool<uint>.Shared.Return(originalData, true);
             }
 
             return r;

--- a/Assets/Scripts/XNAEmulator/Graphics/Texture2D.cs
+++ b/Assets/Scripts/XNAEmulator/Graphics/Texture2D.cs
@@ -198,7 +198,6 @@ namespace Microsoft.Xna.Framework.Graphics
             UnityMainThreadDispatcher.Dispatch(() => SetDataPointerEXTInt(level, rect, data, dataLength));
         }
 
-        // MobileUO: TODO: this work but has graphical issues with some items and the game cursor
         private void SetDataPointerEXTInt(int level, Rectangle? rect, IntPtr data, int dataLength)
         {
             if (data == IntPtr.Zero)

--- a/Assets/Scripts/XNAEmulator/Graphics/Texture2D.cs
+++ b/Assets/Scripts/XNAEmulator/Graphics/Texture2D.cs
@@ -259,5 +259,68 @@ namespace Microsoft.Xna.Framework.Graphics
             destTex.SetPixels32(x, y, w, h, colors, level);
             destTex.Apply();
         }
+
+        // https://github.com/FNA-XNA/FNA/blob/85a8457420278087dc7a81f16661ff68e67b75af/src/Graphics/Texture2D.cs#L268
+        public void GetData<T>(T[] data, int startIndex, int elementCount) where T : struct
+        {
+            GetData(0, null, data, startIndex, elementCount);
+        }
+
+        public void GetData<T>(int level, Rectangle? rect, T[] data, int startIndex, int elementCount) where T : struct
+        {
+            if (data == null || data.Length == 0)
+            {
+                throw new ArgumentException("data cannot be null or empty");
+            }
+            if (data.Length < startIndex + elementCount)
+            {
+                throw new ArgumentException(
+                    $"The data array length is {data.Length}, but {elementCount} elements were requested from start index {startIndex}."
+                );
+            }
+
+            var destTex = UnityTexture as UnityEngine.Texture2D;
+            if (destTex == null)
+            {
+                throw new InvalidOperationException("UnityTexture is not a Texture2D");
+            }
+
+            int x, y, w, h;
+            if (rect.HasValue)
+            {
+                x = rect.Value.X;
+                y = rect.Value.Y;
+                w = rect.Value.Width;
+                h = rect.Value.Height;
+            }
+            else
+            {
+                x = 0;
+                y = 0;
+                w = Math.Max(Width >> level, 1);
+                h = Math.Max(Height >> level, 1);
+            }
+
+            Color32[] colors = destTex.GetPixels32(level);
+            int elementSizeInBytes = Marshal.SizeOf(typeof(T));
+            GCHandle handle = GCHandle.Alloc(data, GCHandleType.Pinned);
+            IntPtr dataPtr = handle.AddrOfPinnedObject() + (startIndex * elementSizeInBytes);
+
+            for (int row = 0; row < h; row++)
+            {
+                for (int col = 0; col < w; col++)
+                {
+                    int colorIndex = (row * w) + col;
+                    int dataIndex = ((h - 1 - row) * w + col) * elementSizeInBytes;
+
+                    if (colorIndex < colors.Length && dataIndex < elementCount * elementSizeInBytes)
+                    {
+                        Marshal.StructureToPtr(colors[colorIndex], dataPtr + dataIndex, false);
+                    }
+                }
+            }
+
+            handle.Free();
+        }
     }
 }

--- a/Assets/Scripts/XNAEmulator/Input/SDL.cs
+++ b/Assets/Scripts/XNAEmulator/Input/SDL.cs
@@ -396,6 +396,8 @@ namespace SDL2
                            (bits << 8)) | bytes;
         }
 
+        private const uint SDL_PREALLOC = 0x00000001;  // Surface uses preallocated memory
+
         public static IntPtr SDL_CreateRGBSurfaceWithFormatFrom(
             IntPtr pixels,
             int width,
@@ -404,10 +406,81 @@ namespace SDL2
             int pitch,
             uint format)
         {
-            return IntPtr.Zero;
+            // Parameter validation
+            if (pixels == IntPtr.Zero)
+            {
+                return IntPtr.Zero;
+            }
+
+            if (width < 0)
+            {
+                return IntPtr.Zero;
+            }
+
+            if (height < 0)
+            {
+                return IntPtr.Zero;
+            }
+
+            // Create a new SDL_Surface structure
+            SDL_Surface surface = new SDL_Surface
+            {
+                flags = (uint)SDL_PREALLOC, // Mark as using external pixel data
+                pixels = pixels,
+                w = width,
+                h = height,
+                pitch = pitch,
+                locked = 0,
+                refcount = 1
+            };
+
+            // Create format structure
+            SDL_PixelFormat pixelFormat = new SDL_PixelFormat
+            {
+                format = format
+            };
+
+            // Allocate memory for the surface structure and copy the data
+            IntPtr surfacePtr = Marshal.AllocHGlobal(Marshal.SizeOf<SDL_Surface>());
+            IntPtr formatPtr = Marshal.AllocHGlobal(Marshal.SizeOf<SDL_PixelFormat>());
+
+            // Copy the format structure to unmanaged memory
+            Marshal.StructureToPtr(pixelFormat, formatPtr, false);
+    
+            // Set the format pointer in the surface
+            surface.format = formatPtr;
+
+            // Set default clip rectangle
+            surface.clip_rect = new SDL_Rect
+            {
+                x = 0,
+                y = 0,
+                w = width,
+                h = height
+            };
+
+            // Copy the surface structure to unmanaged memory
+            Marshal.StructureToPtr(surface, surfacePtr, false);
+
+            return surfacePtr;
         }
 
-        public static void SDL_FreeSurface(IntPtr surface){}
+        public static void SDL_FreeSurface(IntPtr surface){
+            if (surface == IntPtr.Zero)
+                return;
+
+            // Get the surface structure
+            SDL_Surface surfaceStruct = Marshal.PtrToStructure<SDL_Surface>(surface);
+
+            // Free the pixel format if it exists
+            if (surfaceStruct.format != IntPtr.Zero)
+            {
+                Marshal.FreeHGlobal(surfaceStruct.format);
+            }
+
+            // Free the surface structure itself
+            Marshal.FreeHGlobal(surface);
+        }
 
         public static SDL_bool SDL_HasClipboardText()
         {


### PR DESCRIPTION
The next version of CUO drops UOTexture class, so we must use the original CUO implementations for getting textures. This required coming up with implementations for Texture2D's SetDataPointerEXT() and GetData() functions.